### PR TITLE
Upgraded to .NET 8

### DIFF
--- a/src/PaTsa.Conference.App.Maui/PaTsa.Conference.App.Maui.csproj
+++ b/src/PaTsa.Conference.App.Maui/PaTsa.Conference.App.Maui.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net7.0-android;net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net7.0-windows10.0.19041.0</TargetFrameworks>
+		<TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
 		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
-		<!-- <TargetFrameworks>$(TargetFrameworks);net7.0-tizen</TargetFrameworks> -->
+		<!-- <TargetFrameworks>$(TargetFrameworks);net8.0-tizen</TargetFrameworks> -->
 		<OutputType>Exe</OutputType>
 		<RootNamespace>PaTsa.Conference.App.Maui</RootNamespace>
 		<UseMaui>true</UseMaui>
@@ -48,9 +48,11 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="CommunityToolkit.Maui" Version="5.0.0" />
-		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.1.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="7.0.0" />
+		<PackageReference Include="CommunityToolkit.Maui" Version="7.0.1" />
+		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
+    	<PackageReference Include="Microsoft.Maui.Controls" Version="8.0.7" />
+    	<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.7" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
This pull request primarily focuses on updating the .NET version and package versions in the `PaTsa.Conference.App.Maui.csproj` file. The most important changes include updating the target frameworks to .NET 8.0 and updating the versions of the `CommunityToolkit.Maui`, `CommunityToolkit.Mvvm`, and `Microsoft.Extensions.Logging.Debug` packages. Additionally, references to `Microsoft.Maui.Controls` and `Microsoft.Maui.Controls.Compatibility` packages were added.

.NET version update:
* [`src/PaTsa.Conference.App.Maui/PaTsa.Conference.App.Maui.csproj`](diffhunk://#diff-02a5c0192f5c9798acf6147cabea2301b8d3905f3ce2d54a931ef8a1fc698c91L4-R7): The target frameworks have been updated from .NET 7.0 to .NET 8.0. This includes the Android, iOS, Mac Catalyst, and Windows platforms.

Package version updates and additions:
* [`src/PaTsa.Conference.App.Maui/PaTsa.Conference.App.Maui.csproj`](diffhunk://#diff-02a5c0192f5c9798acf6147cabea2301b8d3905f3ce2d54a931ef8a1fc698c91L51-R55): The versions of `CommunityToolkit.Maui`, `CommunityToolkit.Mvvm`, and `Microsoft.Extensions.Logging.Debug` packages have been updated. Additionally, references to `Microsoft.Maui.Controls` and `Microsoft.Maui.Controls.Compatibility` packages have been added.